### PR TITLE
Testes REST Controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ Após a execução do comando, é possível visualizar o relatório de execuçã
 ```shell
 > .\build\reports\tests\test\index.html
 ```
+
+## Cobertura de testes do projeto
+
+Os testes foram construídos, nas diferentes camadas do projeto, utilizando:
+- Testes unitários
+- Testes de integração
+- Testes de comportamento (BDD)
+
+O resumo dos testes de integração e unitários pode ser observado em:
+![tests-summary](https://github.com/richardaltmayer/fiap-hexagonal-architecture/assets/10313123/43658221-1023-4f6d-98c9-9f84713e1e4b)
+
+_Os testes de comportamento não constam no resumo acima._
+
+A cobertura de testes desenvolvidos no projeto pode ser observada em:
+![tests-coverage](https://github.com/richardaltmayer/fiap-hexagonal-architecture/assets/10313123/e70ba972-024b-4e2b-b5ad-c750409ea653)
+
+
+

--- a/src/main/java/com/fiap/restaurant/api/order/OrderRestController.java
+++ b/src/main/java/com/fiap/restaurant/api/order/OrderRestController.java
@@ -54,8 +54,6 @@ public class OrderRestController {
         try {
             OrderController.updatePaymentStatus(updatePaymentStatusDTO.getExternalIdentifier(), updatePaymentStatusDTO.getPaymentStatus(), this.orderDatabaseConnection, this.customerDatabaseConnection);
             return ResponseEntity.ok().body(true);
-        } catch (BusinessException businessException) {
-            return new ResponseEntity<>(businessException.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (ResourceNotFoundException resourceNotFoundException) {
             return new ResponseEntity<>(resourceNotFoundException.getMessage(), HttpStatus.NOT_FOUND);
         }
@@ -66,8 +64,6 @@ public class OrderRestController {
         try {
             OrderController.updateStatus(id, updateOrderStatusDTO.getStatus(), this.orderDatabaseConnection, this.customerDatabaseConnection);
             return ResponseEntity.ok().body(true);
-        } catch (BusinessException businessException) {
-            return new ResponseEntity<>(businessException.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (ResourceNotFoundException resourceNotFoundException) {
             return new ResponseEntity<>(resourceNotFoundException.getMessage(), HttpStatus.NOT_FOUND);
         }

--- a/src/main/java/com/fiap/restaurant/api/product/ImageRestController.java
+++ b/src/main/java/com/fiap/restaurant/api/product/ImageRestController.java
@@ -30,8 +30,13 @@ public class ImageRestController {
     }
 
     @PostMapping(path = "/")
-    public Image saveProductImage(@RequestBody SaveProductImageDTO saveProductImageDTO) {
-        return ImageController.saveProductImage(saveProductImageDTO, this.imageDatabaseConnection, this.productDatabaseConnection, itemDatabaseConnection);
+    public ResponseEntity<Object> saveProductImage(@RequestBody SaveProductImageDTO saveProductImageDTO) {
+        try {
+            Image image = ImageController.saveProductImage(saveProductImageDTO, this.imageDatabaseConnection, this.productDatabaseConnection, itemDatabaseConnection);
+            return ResponseEntity.ok().body(image);
+        } catch (ResourceNotFoundException resourceNotFoundException) {
+            return new ResponseEntity<>(resourceNotFoundException.getMessage(), HttpStatus.NOT_FOUND);
+        }
     }
 
     @PutMapping(path = "/{id}")

--- a/src/main/java/com/fiap/restaurant/api/product/ProductRestController.java
+++ b/src/main/java/com/fiap/restaurant/api/product/ProductRestController.java
@@ -3,7 +3,6 @@ package com.fiap.restaurant.api.product;
 import com.fiap.restaurant.controller.product.ProductController;
 import com.fiap.restaurant.entity.product.Product;
 import com.fiap.restaurant.types.dto.product.ProductDTO;
-import com.fiap.restaurant.types.exception.BusinessException;
 import com.fiap.restaurant.types.exception.ResourceNotFoundException;
 import com.fiap.restaurant.types.interfaces.db.product.ProductDatabaseConnection;
 import org.springframework.http.HttpStatus;
@@ -34,12 +33,8 @@ public class ProductRestController {
 
     @PostMapping(path = "/")
     public ResponseEntity<Object> save(@RequestBody ProductDTO productDTO) {
-        try {
-            Product product = ProductController.save(productDTO, this.productDatabaseConnection);
-            return ResponseEntity.ok().body(product);
-        } catch (BusinessException businessException) {
-            return new ResponseEntity<>(businessException.getMessage(), HttpStatus.BAD_REQUEST);
-        }
+        Product product = ProductController.save(productDTO, this.productDatabaseConnection);
+        return ResponseEntity.ok().body(product);
     }
 
     @PutMapping(path = "/{id}")
@@ -49,8 +44,6 @@ public class ProductRestController {
             return ResponseEntity.ok().body(product);
         } catch (ResourceNotFoundException resourceNotFoundException) {
             return new ResponseEntity<>(resourceNotFoundException.getMessage(), HttpStatus.NOT_FOUND);
-        } catch (BusinessException businessException) {
-            return new ResponseEntity<>(businessException.getMessage(), HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/src/test/java/com/fiap/restaurant/api/customer/CustomerRestControllerIT.java
+++ b/src/test/java/com/fiap/restaurant/api/customer/CustomerRestControllerIT.java
@@ -1,0 +1,133 @@
+package com.fiap.restaurant.api.customer;
+
+import com.fiap.restaurant.external.db.customer.CustomerJpaRepository;
+import com.fiap.restaurant.types.dto.customer.SaveCustomerDTO;
+import com.fiap.restaurant.util.CustomerTestUtil;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+public class CustomerRestControllerIT {
+
+    public static final String PATH = "/customer";
+
+    @Autowired
+    private CustomerJpaRepository customerJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        customerJpaRepository.deleteAll();
+    }
+
+    @Nested
+    class Write {
+
+        @Test
+        void mustSaveCustomer() {
+            SaveCustomerDTO saveCustomerDTO = CustomerTestUtil.generateSaveCustomerDTO("John Doe", "johndoe@email.com", CustomerTestUtil.randomCpf());
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(saveCustomerDTO)
+            .when()
+                    .post(PATH + "/")
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(equalTo("true"));
+        }
+
+        @Test
+        void mustThrowExceptionEmailAlreadyInUse() {
+            final String customerEmail = "johndoe@email.com";
+            customerJpaRepository.save(CustomerTestUtil.generateJpa("John User", customerEmail, CustomerTestUtil.randomCpf()));
+
+            SaveCustomerDTO saveCustomerDTO = CustomerTestUtil.generateSaveCustomerDTO("John Doe", customerEmail, CustomerTestUtil.randomCpf());
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(saveCustomerDTO)
+            .when()
+                    .post(PATH + "/")
+            .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body(equalTo("Cliente já cadastrado com o e-mail informado"));
+        }
+
+        @Test
+        void mustThrowExceptionCpfAlreadyInUse() {
+            final String customerCpf = CustomerTestUtil.randomCpf();
+            customerJpaRepository.save(CustomerTestUtil.generateJpa("John User", "johnuser@email.com", customerCpf));
+
+            SaveCustomerDTO saveCustomerDTO = CustomerTestUtil.generateSaveCustomerDTO("John Doe", "johndoe@email.com", customerCpf);
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(saveCustomerDTO)
+            .when()
+                    .post(PATH + "/")
+            .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body(equalTo("Cliente já cadastrado com o CPF informado"));
+        }
+    }
+
+    @Nested
+    class Read {
+
+        @Test
+        void mustFindCustomerByCpf() {
+            final String customerCpf = CustomerTestUtil.randomCpf();
+            customerJpaRepository.save(CustomerTestUtil.generateJpa("John User", "johnuser@email.com", customerCpf));
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .get(PATH + "/{cpf}", customerCpf)
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasKey("id"))
+                    .body("$", hasKey("name"))
+                    .body("$", hasKey("email"))
+                    .body("$", hasKey("cpf"));
+        }
+
+        @Test
+        void mustThrowExceptionCustomerNotFoundByCpf() {
+            final String customerCpf = CustomerTestUtil.randomCpf();
+            customerJpaRepository.save(CustomerTestUtil.generateJpa("John User", "johnuser@email.com", CustomerTestUtil.randomCpf()));
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .get(PATH + "/{cpf}", customerCpf)
+            .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body(equalTo("Cliente não encontrado"));
+        }
+    }
+}

--- a/src/test/java/com/fiap/restaurant/api/customer/CustomerRestControllerIT.java
+++ b/src/test/java/com/fiap/restaurant/api/customer/CustomerRestControllerIT.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 
@@ -26,6 +27,7 @@ import static org.hamcrest.Matchers.hasKey;
 public class CustomerRestControllerIT {
 
     public static final String PATH = "/customer";
+    private static final String SCHEMA_LOCATION = "./schemas/api/customer";
 
     @Autowired
     private CustomerJpaRepository customerJpaRepository;
@@ -58,7 +60,7 @@ public class CustomerRestControllerIT {
                     .post(PATH + "/")
             .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body(equalTo("true"));
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/CustomerSaveSchema.json"));
         }
 
         @Test
@@ -113,7 +115,8 @@ public class CustomerRestControllerIT {
                     .body("$", hasKey("id"))
                     .body("$", hasKey("name"))
                     .body("$", hasKey("email"))
-                    .body("$", hasKey("cpf"));
+                    .body("$", hasKey("cpf"))
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/CustomerFindByCpfSchema.json"));;
         }
 
         @Test

--- a/src/test/java/com/fiap/restaurant/api/customer/CustomerRestControllerIT.java
+++ b/src/test/java/com/fiap/restaurant/api/customer/CustomerRestControllerIT.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.hasKey;
 @ActiveProfiles("test")
 public class CustomerRestControllerIT {
 
-    public static final String PATH = "/customer";
+    private static final String PATH = "/customer";
     private static final String SCHEMA_LOCATION = "./schemas/api/customer";
 
     @Autowired

--- a/src/test/java/com/fiap/restaurant/api/order/ItemRestControllerIT.java
+++ b/src/test/java/com/fiap/restaurant/api/order/ItemRestControllerIT.java
@@ -1,0 +1,130 @@
+package com.fiap.restaurant.api.order;
+
+import com.fiap.restaurant.external.db.order.ItemJpa;
+import com.fiap.restaurant.external.db.order.ItemJpaRepository;
+import com.fiap.restaurant.external.db.order.ItemProductRepository;
+import com.fiap.restaurant.external.db.product.ImageJpaRepository;
+import com.fiap.restaurant.external.db.product.ProductJpa;
+import com.fiap.restaurant.external.db.product.ProductJpaRepository;
+import com.fiap.restaurant.types.dto.IdDTO;
+import com.fiap.restaurant.types.dto.order.SaveItemDTO;
+import com.fiap.restaurant.types.dto.product.ImageSrcDTO;
+import com.fiap.restaurant.util.ImageTestUtil;
+import com.fiap.restaurant.util.ItemProductTestUtil;
+import com.fiap.restaurant.util.ItemTestUtil;
+import com.fiap.restaurant.util.ProductTestUtil;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+public class ItemRestControllerIT {
+
+    private static final String PATH = "/item";
+    private static final String SCHEMA_LOCATION = "./schemas/api/order";
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private ItemJpaRepository itemJpaRepository;
+
+    @Autowired
+    private ItemProductRepository itemProductRepository;
+
+    @Autowired
+    private ImageJpaRepository imageJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        imageJpaRepository.deleteAll();
+        itemProductRepository.deleteAll();
+        productJpaRepository.deleteAll();
+        itemJpaRepository.deleteAll();
+    }
+
+    @Test
+    void mustSaveItem() {
+        ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Drink 1", "Description 1", "DRINK", 7.5));
+
+        SaveItemDTO saveItemDTO = ItemTestUtil.generateSaveItemDTO("Item 1", "Item Description 1", 19.9);
+        saveItemDTO.getProductIdList().add(new IdDTO(productJpa.getId()));
+        saveItemDTO.getImageSrcList().add(new ImageSrcDTO("http://image1.test"));
+        saveItemDTO.getImageSrcList().add(new ImageSrcDTO("http://image2.test"));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(saveItemDTO)
+        .when()
+                .post(PATH + "/")
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ItemSaveSchema.json"));
+    }
+
+    @Test
+    void mustThrowExceptionProductListNotFoundOnSaveItem() {
+        SaveItemDTO saveItemDTO = ItemTestUtil.generateSaveItemDTO("Item 1", "Item Description 1", 19.9);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(saveItemDTO)
+        .when()
+                .post(PATH + "/")
+        .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body(equalTo("O(s) produto(s) do item não informado(s)"));
+    }
+
+    @Test
+    void mustDeleteItem() {
+        ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Drink 1", "Description 1", "DRINK", 7.5));
+        ItemJpa itemJpa = itemJpaRepository.save(ItemTestUtil.generateJpa("Item 1", "Description 1", 6.5));
+        itemProductRepository.save(ItemProductTestUtil.generateJpa(itemJpa, productJpa));
+        imageJpaRepository.save(ImageTestUtil.generateJpa(itemJpa, "http://image.test"));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+                .delete(PATH + "/{id}", itemJpa.getId())
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ItemDeleteSchema.json"));
+    }
+
+    @Test
+    void mustThrowExceptionIdNotFoundOnDeleteItem() {
+        final Long nonexistentItemId = 0L;
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+                .delete(PATH + "/{id}", nonexistentItemId)
+        .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body(equalTo("Item não encontrado"));
+    }
+}

--- a/src/test/java/com/fiap/restaurant/api/order/OrderRestControllerIT.java
+++ b/src/test/java/com/fiap/restaurant/api/order/OrderRestControllerIT.java
@@ -1,0 +1,186 @@
+package com.fiap.restaurant.api.order;
+
+import com.fiap.restaurant.entity.order.OrderPaymentStatus;
+import com.fiap.restaurant.entity.order.OrderStatus;
+import com.fiap.restaurant.external.db.customer.CustomerJpa;
+import com.fiap.restaurant.external.db.customer.CustomerJpaRepository;
+import com.fiap.restaurant.external.db.order.*;
+import com.fiap.restaurant.external.db.product.ImageJpaRepository;
+import com.fiap.restaurant.external.db.product.ProductJpa;
+import com.fiap.restaurant.external.db.product.ProductJpaRepository;
+import com.fiap.restaurant.types.dto.order.UpdateOrderStatusDTO;
+import com.fiap.restaurant.types.dto.order.UpdatePaymentStatusDTO;
+import com.fiap.restaurant.util.*;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Date;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.equalTo;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+public class OrderRestControllerIT {
+
+    private static final String PATH = "/order";
+    private static final String SCHEMA_LOCATION = "./schemas/api/order";
+
+    @Autowired
+    private CustomerJpaRepository customerJpaRepository;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private ItemJpaRepository itemJpaRepository;
+
+    @Autowired
+    private ItemProductRepository itemProductRepository;
+
+    @Autowired
+    private ImageJpaRepository imageJpaRepository;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    private OrderItemJpaRepository orderItemJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        imageJpaRepository.deleteAll();
+        itemProductRepository.deleteAll();
+        productJpaRepository.deleteAll();
+        orderItemJpaRepository.deleteAll();
+        itemJpaRepository.deleteAll();
+        orderJpaRepository.deleteAll();
+        customerJpaRepository.deleteAll();
+    }
+
+    @Test
+    void mustUpdateOrderStatus() {
+        CustomerJpa customerJpa = customerJpaRepository.save(CustomerTestUtil.generateJpa("John User", "johndoe@email.com", CustomerTestUtil.randomCpf()));
+        ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Drink 1", "Description 1", "DRINK", 7.5));
+        ItemJpa itemJpa = itemJpaRepository.save(ItemTestUtil.generateJpa("Item 1", "Description 1", 6.5));
+        itemProductRepository.save(ItemProductTestUtil.generateJpa(itemJpa, productJpa));
+        imageJpaRepository.save(ImageTestUtil.generateJpa(itemJpa, "http://image.test"));
+        OrderJpa orderJpa = orderJpaRepository.save(OrderTestUtil.generateJpa(customerJpa, OrderStatus.RECEIVED, OrderPaymentStatus.PENDING, new Date()));
+        orderItemJpaRepository.save(OrderItemTestUtil.generateJpa(orderJpa, itemJpa, "Observation"));
+
+        UpdateOrderStatusDTO updateOrderStatusDTO = OrderTestUtil.generateUpdateStatusDTO(OrderStatus.READY);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(updateOrderStatusDTO)
+        .when()
+                .post(PATH + "/{id}/status", orderJpa.getId())
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/OrderUpdateStatusSchema.json"));
+    }
+
+    @Test
+    void mustThrowExceptionOrderNotFoundOnUpdateOrderStatus() {
+        final Long nonexistentOrderId = 0L;
+        UpdateOrderStatusDTO updateOrderStatusDTO = OrderTestUtil.generateUpdateStatusDTO(OrderStatus.READY);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(updateOrderStatusDTO)
+        .when()
+                .post(PATH + "/{id}/status", nonexistentOrderId)
+        .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body(equalTo("Pedido não encontrado"));
+    }
+
+    @Test
+    void mustUpdateOrderPaymentStatus() {
+        CustomerJpa customerJpa = customerJpaRepository.save(CustomerTestUtil.generateJpa("John User", "johndoe@email.com", CustomerTestUtil.randomCpf()));
+        ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Drink 1", "Description 1", "DRINK", 7.5));
+        ItemJpa itemJpa = itemJpaRepository.save(ItemTestUtil.generateJpa("Item 1", "Description 1", 6.5));
+        itemProductRepository.save(ItemProductTestUtil.generateJpa(itemJpa, productJpa));
+        imageJpaRepository.save(ImageTestUtil.generateJpa(itemJpa, "http://image.test"));
+        OrderJpa orderJpa = orderJpaRepository.save(OrderTestUtil.generateJpa(customerJpa, OrderStatus.RECEIVED, OrderPaymentStatus.PENDING, new Date()));
+        orderItemJpaRepository.save(OrderItemTestUtil.generateJpa(orderJpa, itemJpa, "Observation"));
+
+        UpdatePaymentStatusDTO updatePaymentStatusDTO = OrderTestUtil.generateUpdatePaymentStatusDTO(orderJpa.getId(), OrderPaymentStatus.APPROVED);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(updatePaymentStatusDTO)
+        .when()
+                .post(PATH + "/webhookPaymentStatus")
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/OrderUpdatePaymentStatusSchema.json"));
+    }
+
+    @Test
+    void mustThrowExceptionOrderNotFoundOnUpdateOrderPaymentStatus() {
+        final Long nonexistentOrderId = 0L;
+        UpdatePaymentStatusDTO updatePaymentStatusDTO = OrderTestUtil.generateUpdatePaymentStatusDTO(nonexistentOrderId, OrderPaymentStatus.APPROVED);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(updatePaymentStatusDTO)
+        .when()
+                .post(PATH + "/webhookPaymentStatus")
+        .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body(equalTo("Pedido não encontrado"));
+    }
+
+    @Test
+    void mustFindOrderById() {
+        CustomerJpa customerJpa = customerJpaRepository.save(CustomerTestUtil.generateJpa("John User", "johndoe@email.com", CustomerTestUtil.randomCpf()));
+        ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Drink 1", "Description 1", "DRINK", 7.5));
+        ItemJpa itemJpa = itemJpaRepository.save(ItemTestUtil.generateJpa("Item 1", "Description 1", 6.5));
+        itemProductRepository.save(ItemProductTestUtil.generateJpa(itemJpa, productJpa));
+        imageJpaRepository.save(ImageTestUtil.generateJpa(itemJpa, "http://image.test"));
+        OrderJpa orderJpa = orderJpaRepository.save(OrderTestUtil.generateJpa(customerJpa, OrderStatus.RECEIVED, OrderPaymentStatus.PENDING, new Date()));
+        orderItemJpaRepository.save(OrderItemTestUtil.generateJpa(orderJpa, itemJpa, "Observation"));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+                .get(PATH + "/{id}", orderJpa.getId())
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/OrderFindSchema.json"));
+    }
+
+    @Test
+    void mustThrowExceptionOrderIdNotFound() {
+        final Long nonexistentOrderId = 0L;
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+                .get(PATH + "/{id}", nonexistentOrderId)
+        .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body(equalTo("Pedido não encontrado"));
+    }
+}

--- a/src/test/java/com/fiap/restaurant/api/product/ImageRestControllerIT.java
+++ b/src/test/java/com/fiap/restaurant/api/product/ImageRestControllerIT.java
@@ -1,0 +1,178 @@
+package com.fiap.restaurant.api.product;
+
+import com.fiap.restaurant.external.db.product.ImageJpa;
+import com.fiap.restaurant.external.db.product.ImageJpaRepository;
+import com.fiap.restaurant.external.db.product.ProductJpa;
+import com.fiap.restaurant.external.db.product.ProductJpaRepository;
+import com.fiap.restaurant.types.dto.product.SaveProductImageDTO;
+import com.fiap.restaurant.types.dto.product.UpdateImageDTO;
+import com.fiap.restaurant.util.ImageTestUtil;
+import com.fiap.restaurant.util.ProductTestUtil;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+public class ImageRestControllerIT {
+
+    private static final String PATH = "/image";
+    private static final String SCHEMA_LOCATION = "./schemas/api/product";
+
+    @Autowired
+    private ImageJpaRepository imageJpaRepository;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        imageJpaRepository.deleteAll();
+        productJpaRepository.deleteAll();
+    }
+
+    @Nested
+    class Write {
+
+        @Test
+        void mustSaveProductImage() {
+            ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 4.99));
+
+            SaveProductImageDTO saveProductImageDTO = ImageTestUtil.generateSaveProductImageDTO(productJpa.getId(), "http://image.test");
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(saveProductImageDTO)
+                    .when()
+            .post(PATH + "/")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasKey("id"))
+                    .body("$", hasKey("src"))
+                    .body("$", hasKey("product"))
+                    .body("$", hasKey("item"))
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ImageSaveSchema.json"));
+        }
+
+        @Test
+        void mustThrowExceptionProductNotFoundOnSaveProductImage() {
+            final Long nonexistentProductId = 0L;
+            SaveProductImageDTO saveProductImageDTO = ImageTestUtil.generateSaveProductImageDTO(nonexistentProductId, "http://image.test");
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(saveProductImageDTO)
+            .when()
+                    .post(PATH + "/")
+            .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body(equalTo("Produto não encontrado."));
+        }
+
+        @Test
+        void mustUpdateImage() {
+            ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 4.99));
+            ImageJpa imageJpa = imageJpaRepository.save(ImageTestUtil.generateJpa(productJpa, "http://image.test"));
+
+            UpdateImageDTO updateImageDTO = ImageTestUtil.generateUpdateImageDTO("http://image2.test");
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(updateImageDTO)
+            .when()
+                    .put(PATH + "/{id}", imageJpa.getId())
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasKey("id"))
+                    .body("$", hasKey("src"))
+                    .body("$", hasKey("product"))
+                    .body("$", hasKey("item"))
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ImageSaveSchema.json"));
+        }
+
+        @Test
+        void mustThrowExceptionImageNotFoundOnUpdateImage() {
+            final Long nonexistentImageId = 0L;
+            UpdateImageDTO updateImageDTO = ImageTestUtil.generateUpdateImageDTO("http://image2.test");
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(updateImageDTO)
+            .when()
+                    .put(PATH + "/{id}", nonexistentImageId)
+            .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body(equalTo("Imagem não encontrada"));
+        }
+
+        @Test
+        void mustDeleteImage() {
+            ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 4.99));
+            ImageJpa imageJpa = imageJpaRepository.save(ImageTestUtil.generateJpa(productJpa, "http://image.test"));
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .delete(PATH + "/{id}", imageJpa.getId())
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ImageDeleteSchema.json"));
+        }
+
+        @Test
+        void mustThrowExceptionImageNotFoundOnDeleteImage() {
+            final Long nonexistentImageId = 0L;
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .delete(PATH + "/{id}", nonexistentImageId)
+            .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body(equalTo("Imagem não encontrada"));
+        }
+    }
+
+    @Nested
+    class Read {
+
+        @Test
+        void mustFindAllImageByProductId() {
+            ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 4.99));
+            imageJpaRepository.save(ImageTestUtil.generateJpa(productJpa, "http://image1.test"));
+            imageJpaRepository.save(ImageTestUtil.generateJpa(productJpa, "http://image2.test"));
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .get(PATH + "/productId={productId}", productJpa.getId())
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ImageListSchema.json"));
+        }
+    }
+}

--- a/src/test/java/com/fiap/restaurant/api/product/ProductRestControllerIT.java
+++ b/src/test/java/com/fiap/restaurant/api/product/ProductRestControllerIT.java
@@ -1,0 +1,179 @@
+package com.fiap.restaurant.api.product;
+
+import com.fiap.restaurant.external.db.product.ProductJpa;
+import com.fiap.restaurant.external.db.product.ProductJpaRepository;
+import com.fiap.restaurant.types.dto.product.ProductDTO;
+import com.fiap.restaurant.util.ProductTestUtil;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+public class ProductRestControllerIT {
+
+    private static final String PATH = "/product";
+    private static final String SCHEMA_LOCATION = "./schemas/api/product";
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        productJpaRepository.deleteAll();
+    }
+
+    @Nested
+    class Write {
+
+        @Test
+        void mustSaveProduct() {
+            ProductDTO productDTO = ProductTestUtil.generateDTO("Drink 1", "Description 1", "DRINK", 7.5);
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(productDTO)
+            .when()
+                    .post(PATH + "/")
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasKey("id"))
+                    .body("$", hasKey("name"))
+                    .body("$", hasKey("description"))
+                    .body("$", hasKey("price"))
+                    .body("$", hasKey("category"))
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ProductSaveSchema.json"));
+        }
+        
+        @Test
+        void mustUpdateProduct() {
+            final String name = "Product 1";
+            final String description = "Description 1";
+            final Double price = 4.99;
+            final String category = "DRINK";
+            ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa(name, description, category, price));
+
+            ProductDTO productDTO = ProductTestUtil.generateDTO(name, description, category, price);
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(productDTO)
+            .when()
+                    .put(PATH + "/{id}", productJpa.getId())
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("$", hasKey("id"))
+                    .body("$", hasKey("name"))
+                    .body("$", hasKey("description"))
+                    .body("$", hasKey("price"))
+                    .body("$", hasKey("category"))
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ProductSaveSchema.json"));
+        }
+
+        @Test
+        void mustThrowExceptionIdNotFoundOnUpdateProduct() {
+            final String name = "Product 1";
+            final String description = "Description 1";
+            final Double price = 4.99;
+            final String category = "DRINK";
+            productJpaRepository.save(ProductTestUtil.generateJpa(name, description, category, price));
+
+            ProductDTO productDTO = ProductTestUtil.generateDTO(name, description, category, price);
+            final Long nonexistentProductId = 0L;
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(productDTO)
+            .when()
+                    .put(PATH + "/{id}", nonexistentProductId)
+            .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body(equalTo("Produto não encontrado"));
+        }
+
+        @Test
+        void mustDeleteProduct() {
+            ProductJpa productJpa = productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 4.99));
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .delete(PATH + "/{id}", productJpa.getId())
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ProductDeleteSchema.json"));
+        }
+
+        @Test
+        void mustThrowExceptionIdNotFoundOnDeleteProduct() {
+            productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 4.99));
+
+            final Long nonexistentProductId = 0L;
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .delete(PATH + "/{id}", nonexistentProductId)
+            .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value());
+        }
+    }
+
+    @Nested
+    class Read {
+
+        @Test
+        void mustFindAllProducts() {
+            productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 5.0));
+            productJpaRepository.save(ProductTestUtil.generateJpa("Product 2", "Description 2", "DRINK", 10.0));
+            productJpaRepository.save(ProductTestUtil.generateJpa("Product 3", "Description 3", "SNACK", 15.0));
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .get(PATH + "/")
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ProductListSchema.json"));
+        }
+
+        @Test
+        void mustFindAllProductByCategory() {
+            productJpaRepository.save(ProductTestUtil.generateJpa("Product 1", "Description 1", "DRINK", 5.0));
+            productJpaRepository.save(ProductTestUtil.generateJpa("Product 2", "Description 2", "DRINK", 10.0));
+            productJpaRepository.save(ProductTestUtil.generateJpa("Product 3", "Description 3", "SNACK", 15.0));
+
+            given()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+                    .get(PATH + "/listByCategory/{category}", "DRINK")
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body(matchesJsonSchemaInClasspath(SCHEMA_LOCATION + "/ProductListSchema.json"));
+        }
+    }
+}

--- a/src/test/java/com/fiap/restaurant/bdd/order/OrderStepdefs.java
+++ b/src/test/java/com/fiap/restaurant/bdd/order/OrderStepdefs.java
@@ -123,8 +123,7 @@ public class OrderStepdefs {
 
     @When("the order status is updated")
     public void theOrderStatusIsUpdated() {
-        UpdateOrderStatusDTO updateOrderStatusDTO = new UpdateOrderStatusDTO();
-        updateOrderStatusDTO.setStatus("READY");
+        UpdateOrderStatusDTO updateOrderStatusDTO = OrderTestUtil.generateUpdateStatusDTO(OrderStatus.READY);
 
         response = given().contentType(DEFAULT_CONTENT_TYPE).body(updateOrderStatusDTO)
                 .when().post(ENDPOINT + "/{id}/status", savedOrderId);
@@ -139,8 +138,7 @@ public class OrderStepdefs {
 
     @When("the nonexistent order status is updated")
     public void theNonexistentOrderStatusIsUpdated() {
-        UpdateOrderStatusDTO updateOrderStatusDTO = new UpdateOrderStatusDTO();
-        updateOrderStatusDTO.setStatus(OrderStatus.READY.toString());
+        UpdateOrderStatusDTO updateOrderStatusDTO = OrderTestUtil.generateUpdateStatusDTO(OrderStatus.READY);
 
         final Long nonexistentOrderId = 0L;
 
@@ -150,9 +148,7 @@ public class OrderStepdefs {
 
     @When("the order payment status is updated")
     public void theOrderPaymentStatusIsUpdated() {
-        UpdatePaymentStatusDTO updatePaymentStatusDTO = new UpdatePaymentStatusDTO();
-        updatePaymentStatusDTO.setPaymentStatus(OrderPaymentStatus.APPROVED.toString());
-        updatePaymentStatusDTO.setExternalIdentifier(savedOrderId.longValue());
+        UpdatePaymentStatusDTO updatePaymentStatusDTO = OrderTestUtil.generateUpdatePaymentStatusDTO(savedOrderId.longValue(), OrderPaymentStatus.APPROVED);
 
         response = given().contentType(DEFAULT_CONTENT_TYPE).body(updatePaymentStatusDTO)
                 .when().post(ENDPOINT + "/webhookPaymentStatus");

--- a/src/test/java/com/fiap/restaurant/entity/customer/CustomerTest.java
+++ b/src/test/java/com/fiap/restaurant/entity/customer/CustomerTest.java
@@ -12,9 +12,13 @@ public class CustomerTest {
         final String name = "Customer name";
         final String email = "customer@teste.com";
         final String cpf = CustomerTestUtil.CPF;
+        final Long id = 1L;
 
         Customer customer = new Customer(name, email, cpf);
+        customer.setId(id);
+
         assertThat(customer).isNotNull();
+        assertThat(customer.getId()).isEqualTo(id);
         assertThat(customer.getName()).isEqualTo(name);
         assertThat(customer.getEmail()).isEqualTo(email);
         assertThat(customer.getCpf()).isEqualTo(cpf);

--- a/src/test/java/com/fiap/restaurant/entity/order/OrderTest.java
+++ b/src/test/java/com/fiap/restaurant/entity/order/OrderTest.java
@@ -1,11 +1,13 @@
 package com.fiap.restaurant.entity.order;
 
 import com.fiap.restaurant.entity.customer.Customer;
+import com.fiap.restaurant.entity.product.Product;
 import com.fiap.restaurant.util.CustomerTestUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,5 +33,48 @@ public class OrderTest {
         assertThat(order.getStatus()).isEqualTo(status);
         assertThat(order.getPaymentStatus()).isEqualTo(paymentStatus);
         assertThat(order.getItems()).isEmpty();
+    }
+
+    @Test
+    void mustCalculateTotalValueByItemPrice() {
+        final Customer customer = new Customer("Customer name", "customer@teste.com", CustomerTestUtil.CPF);
+        final Double itemPrice = 17.5;
+
+        Item item = new Item("Item 1", "Description", itemPrice);
+        Order order = new Order(customer, new Date(), OrderStatus.RECEIVED, OrderPaymentStatus.PENDING, new ArrayList<>());
+        OrderItem orderItem = new OrderItem(order, item, "Observation");
+
+        List<OrderItem> orderItemList = new ArrayList<>();
+        orderItemList.add(orderItem);
+
+        Product product = new Product("Product 1", "Description 1", 12.0, "SNACK");
+        ItemProduct itemProduct = new ItemProduct(item, product);
+
+        item.addItemProduct(itemProduct);
+        order.setItems(orderItemList);
+
+        assertThat(order.getTotalValue()).isEqualTo(itemPrice);
+    }
+
+    @Test
+    void mustCalculateTotalValueByProductPrice() {
+        final Customer customer = new Customer("Customer name", "customer@teste.com", CustomerTestUtil.CPF);
+
+        Item item = new Item("Item 1", "Description", null);
+        Order order = new Order(customer, new Date(), OrderStatus.RECEIVED, OrderPaymentStatus.PENDING, new ArrayList<>());
+        OrderItem orderItem = new OrderItem(order, item, "Observation");
+
+        List<OrderItem> orderItemList = new ArrayList<>();
+        orderItemList.add(orderItem);
+
+        final Double productPrice = 12.5;
+
+        Product product = new Product("Product 1", "Description 1", productPrice, "SNACK");
+        ItemProduct itemProduct = new ItemProduct(item, product);
+
+        item.addItemProduct(itemProduct);
+        order.setItems(orderItemList);
+
+        assertThat(order.getTotalValue()).isEqualTo(productPrice);
     }
 }

--- a/src/test/java/com/fiap/restaurant/usecase/customer/CustomerUseCaseIT.java
+++ b/src/test/java/com/fiap/restaurant/usecase/customer/CustomerUseCaseIT.java
@@ -59,8 +59,6 @@ public class CustomerUseCaseIT {
             assertThatThrownBy(() -> CustomerUseCase.save(secondSaveCustomerDTO, customerGateway))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage("Cliente já cadastrado com o e-mail informado");
-
-
         }
 
         @Test

--- a/src/test/java/com/fiap/restaurant/usecase/order/ItemUseCaseIT.java
+++ b/src/test/java/com/fiap/restaurant/usecase/order/ItemUseCaseIT.java
@@ -110,7 +110,7 @@ public class ItemUseCaseIT {
 
     @Test
     @Rollback
-    void mustThrowExceptionProductListOnSaveItem() {
+    void mustThrowExceptionProductListNotFoundOnSaveItem() {
         SaveItemDTO saveItemDTO = ItemTestUtil.generateSaveItemDTO("Item 1", "Item Description 1", 19.9);
 
         assertThatThrownBy(() -> ItemUseCase.save(saveItemDTO, itemGateway, productGateway, itemProductGateway, imageGateway))

--- a/src/test/java/com/fiap/restaurant/usecase/product/ImageUseCaseIT.java
+++ b/src/test/java/com/fiap/restaurant/usecase/product/ImageUseCaseIT.java
@@ -104,7 +104,6 @@ public class ImageUseCaseIT {
             saveProductImageDTO.setSrc("http://image.test");
 
             Image image = ImageUseCase.saveProductImage(saveProductImageDTO, imageGateway, productGateway);
-            assertThat(image).isNotNull();
 
             UpdateImageDTO updateImageDTO = new UpdateImageDTO();
             updateImageDTO.setSrc("http://image2.test");
@@ -117,11 +116,13 @@ public class ImageUseCaseIT {
 
         @Test
         @Rollback
-        void mustThrowExceptionProductNotFoundOnUpdateImage() {
+        void mustThrowExceptionImageNotFoundOnUpdateImage() {
             UpdateImageDTO updateImageDTO = new UpdateImageDTO();
             updateImageDTO.setSrc("http://image2.test");
 
-            assertThatThrownBy(() -> ImageUseCase.update(1L, updateImageDTO, imageGateway))
+            final Long nonexistentImageId = 0L;
+
+            assertThatThrownBy(() -> ImageUseCase.update(nonexistentImageId, updateImageDTO, imageGateway))
                     .isInstanceOf(ResourceNotFoundException.class)
                     .hasMessage("Imagem não encontrada");
         }
@@ -137,8 +138,6 @@ public class ImageUseCaseIT {
             saveProductImageDTO.setSrc("http://image.test");
 
             Image image = ImageUseCase.saveProductImage(saveProductImageDTO, imageGateway, productGateway);
-            assertThat(image).isNotNull();
-
             ImageUseCase.delete(image.getId(), imageGateway);
 
             Optional<ImageJpa> optionalImage = imageJpaRepository.findById(image.getId());
@@ -147,8 +146,10 @@ public class ImageUseCaseIT {
 
         @Test
         @Rollback
-        void mustThrowExceptionProductNotFoundOnDeleteImage() {
-            assertThatThrownBy(() -> ImageUseCase.delete(1L, imageGateway))
+        void mustThrowExceptionImageNotFoundOnDeleteImage() {
+            final Long nonexistentImageId = 0L;
+
+            assertThatThrownBy(() -> ImageUseCase.delete(nonexistentImageId, imageGateway))
                     .isInstanceOf(ResourceNotFoundException.class)
                     .hasMessage("Imagem não encontrada");
         }

--- a/src/test/java/com/fiap/restaurant/util/OrderTestUtil.java
+++ b/src/test/java/com/fiap/restaurant/util/OrderTestUtil.java
@@ -6,6 +6,8 @@ import com.fiap.restaurant.external.db.customer.CustomerJpa;
 import com.fiap.restaurant.external.db.order.OrderJpa;
 import com.fiap.restaurant.types.dto.order.OrderItemDTO;
 import com.fiap.restaurant.types.dto.order.SaveOrderDTO;
+import com.fiap.restaurant.types.dto.order.UpdateOrderStatusDTO;
+import com.fiap.restaurant.types.dto.order.UpdatePaymentStatusDTO;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -28,5 +30,20 @@ public class OrderTestUtil {
         saveOrderDTO.setItems(Arrays.stream(orderItemDTOList).toList());
 
         return saveOrderDTO;
+    }
+
+    public static UpdateOrderStatusDTO generateUpdateStatusDTO(OrderStatus orderStatus) {
+        UpdateOrderStatusDTO updateOrderStatusDTO = new UpdateOrderStatusDTO();
+        updateOrderStatusDTO.setStatus(orderStatus.toString());
+
+        return updateOrderStatusDTO;
+    }
+
+    public static UpdatePaymentStatusDTO generateUpdatePaymentStatusDTO(Long orderId, OrderPaymentStatus orderPaymentStatus) {
+        UpdatePaymentStatusDTO updatePaymentStatusDTO = new UpdatePaymentStatusDTO();
+        updatePaymentStatusDTO.setExternalIdentifier(orderId);
+        updatePaymentStatusDTO.setPaymentStatus(orderPaymentStatus.toString());
+
+        return updatePaymentStatusDTO;
     }
 }


### PR DESCRIPTION
### Objetivo
Testes de integração sobre controllers REST da aplicação.

Por ser o último PR de criação de testes dessa fase, incluí no `README.md` do projeto uma seção indicando os dados de cobertura dos testes.

As mesmas evidências são relacionadas aqui nesse PR.

Cobertura de testes:
![tests-coverage](https://github.com/richardaltmayer/fiap-hexagonal-architecture/assets/10313123/7252879f-2f5c-4b48-99ef-6e3ccd99ccf6)

Resumo dos testes:
![tests-summary](https://github.com/richardaltmayer/fiap-hexagonal-architecture/assets/10313123/72d5ba47-2de3-4257-b7b8-748a359cff89)